### PR TITLE
Always fetch all commit history

### DIFF
--- a/bin/regular_mvn_build_deploy_analyze
+++ b/bin/regular_mvn_build_deploy_analyze
@@ -11,15 +11,15 @@
 
 set -euo pipefail
 
+# Fetch all commit history so that SonarQube has exact blame information
+# for issue auto-assignment
+# This command can fail with "fatal: --unshallow on a complete repository does not make sense" 
+# if there are not enough commits in the Git repository (even if Travis executed git clone --depth 50).
+# For this reason errors are ignored with "|| true"
+git fetch --unshallow || true
+
 if [ "${TRAVIS_BRANCH}" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   echo '======= Build, deploy and analyze master'
-
-  # Fetch all commit history so that SonarQube has exact blame information
-  # for issue auto-assignment
-  # This command can fail with "fatal: --unshallow on a complete repository does not make sense" 
-  # if there are not enough commits in the Git repository (even if Travis executed git clone --depth 50).
-  # For this reason errors are ignored with "|| true"
-  git fetch --unshallow || true
 
   # Analyze with SNAPSHOT version as long as SQ does not correctly handle
   # purge of release data


### PR DESCRIPTION
You can test it by replacing `curl -sSL https://github.com/SonarSource/travis-utils/tarball/v39 | tar zx --strip-components 1 -C ~/.local` with `curl -sSL https://github.com/SonarSource/travis-utils/tarball/64bf9409783a98c4b2eb47a0d82ac58671ca748a | tar zx --strip-components 1 -C ~/.local` 