### PR TITLE
Update installMaven35

### DIFF
--- a/bin/installMaven35
+++ b/bin/installMaven35
@@ -5,5 +5,5 @@
 
 set -euo pipefail
 
-. installMaven 3.5.2
+. installMaven 3.5.4
 


### PR DESCRIPTION
Updating to the latest [SonarSource/parent-oss](https://github.com/SonarSource/parent-oss) on the [SonarSource/orchestrator](https://github.com/SonarSource/orchestrator) project fails the build with the following message:

> [ERROR] Failed to execute goal org.codehaus.mojo:license-maven-plugin:2.0.0:aggregate-add-third-party (default-cli) on project orchestrator-parent: The plugin org.codehaus.mojo:license-maven-plugin:2.0.0 requires Maven version 3.5.4 -> [Help 1]

See https://github.com/SonarSource/orchestrator/pull/96.

We use Maven 3.5.2. This updates it to the latest 3.5 version (3.5.4).